### PR TITLE
Camera-relative light SSBO (fix lights far from origin) - MC 1.21.11

### DIFF
--- a/src/main/java/org/qualet/irl/light/FramePipeline.java
+++ b/src/main/java/org/qualet/irl/light/FramePipeline.java
@@ -98,6 +98,9 @@ public final class FramePipeline
         }
         ShadowBaker.bake(world, cameraPos, cameraForward, tickDelta);
 
-        LightRegistry.flush();
+        // Camera-relative SSBO upload: subtract the camera origin so light
+        // positions stay precise far from world origin (the .irlights patches
+        // drop the matching + cameraPosition reconstruction on the shader side).
+        LightRegistry.flush(cameraPos.x, cameraPos.y, cameraPos.z);
     }
 }

--- a/src/main/java/org/qualet/irl/light/LightBuffer.java
+++ b/src/main/java/org/qualet/irl/light/LightBuffer.java
@@ -13,7 +13,7 @@ import java.nio.ByteBuffer;
  * std430 contract (the patcher's GLSL must mirror this exactly):
  *
  *   struct Light {
- *       vec4 posRadius;       // xyz = world position, w = radius
+ *       vec4 posRadius;       // xyz = position RELATIVE TO CAMERA (eye), w = radius
  *       vec4 colorIntensity;  // rgb = linear color, a = intensity
  *       vec4 dirType;         // xyz = direction (spot, normalized), w = type (0 point, 1 spot)
  *       vec4 cone;            // x = cos(outerAngle/2), y = cos(innerAngle/2), z = lightMask (0 all, 1 entities only, 2 blocks only), w = bulbSize (0 = use global)

--- a/src/main/java/org/qualet/irl/light/LightRegistry.java
+++ b/src/main/java/org/qualet/irl/light/LightRegistry.java
@@ -163,8 +163,28 @@ public final class LightRegistry
         count = 0;
     }
 
-    /** Pack the accumulated set into the GPU buffer and reset for the next frame. */
+    /** Pack the accumulated set into the GPU buffer (absolute world positions) and
+     *  reset for the next frame. Kept for ABI compatibility — delegates to the
+     *  camera-relative flush with a zero origin (= absolute). */
     public static void flush()
+    {
+        flush(0.0, 0.0, 0.0);
+    }
+
+    /** Pack the accumulated set into the GPU buffer with positions made RELATIVE to
+     *  {@code origin} (the camera/eye), then reset for the next frame.
+     *
+     *  <p>Light positions are collected in absolute world coordinates (kept absolute in
+     *  this registry so the shadow baker can query world blocks), but the SSBO — and the
+     *  shader that reads it — must work in camera-relative space: at large world
+     *  coordinates the absolute float positions and the shaderpack's reconstructed
+     *  fragment position lose precision against each other and the light visibly stops
+     *  lighting. Subtracting the camera origin here (and dropping the matching
+     *  {@code + cameraPosition} reconstruction in the GLSL patches) keeps both sides of
+     *  the {@code light.pos - fragPos} comparison small and precise. The subtraction is
+     *  done in double so it stays exact regardless of distance from origin. Directions
+     *  (spot) are NOT translated.</p> */
+    public static void flush(double originX, double originY, double originZ)
     {
         LightBuffer.begin();
 
@@ -174,13 +194,17 @@ public final class LightRegistry
             // entities-only wins the (UI-prevented) both-set case.
             float lightMask = entitiesOnly[i] ? 1F : (blocksOnly[i] ? 2F : 0F);
 
+            float rx = (float) ((double) px[i] - originX);
+            float ry = (float) ((double) py[i] - originY);
+            float rz = (float) ((double) pz[i] - originZ);
+
             if (type[i] == 0)
             {
-                LightBuffer.addPoint(px[i], py[i], pz[i], cr[i], cg[i], cb[i], intensity[i], radius[i], lightMask, anisotropy[i], density[i], beam[i], (float) shadowTile[i], bulbSize[i]);
+                LightBuffer.addPoint(rx, ry, rz, cr[i], cg[i], cb[i], intensity[i], radius[i], lightMask, anisotropy[i], density[i], beam[i], (float) shadowTile[i], bulbSize[i]);
             }
             else
             {
-                LightBuffer.addSpot(px[i], py[i], pz[i], dx[i], dy[i], dz[i], cr[i], cg[i], cb[i], intensity[i], radius[i], cosOuter[i], cosInner[i], lightMask, anisotropy[i], density[i], beam[i], (float) shadowTile[i], bulbSize[i], cookieLayer[i], cookieRot[i], cookieScale[i], cookieFlags[i]);
+                LightBuffer.addSpot(rx, ry, rz, dx[i], dy[i], dz[i], cr[i], cg[i], cb[i], intensity[i], radius[i], cosOuter[i], cosInner[i], lightMask, anisotropy[i], density[i], beam[i], (float) shadowTile[i], bulbSize[i], cookieLayer[i], cookieRot[i], cookieScale[i], cookieFlags[i]);
             }
         }
 


### PR DESCRIPTION
Ports zqicev's camera-relative light SSBO fix to the `1.21.11` branch (already on `main` as #1).

Far from world origin (around X = 100k) the absolute float light position and the shaderpack's reconstructed fragment position lose precision against each other, so the light visibly stops lighting. `LightRegistry.flush(originX, originY, originZ)` subtracts the camera origin (in double) before packing — the no-arg `flush()` is kept and delegates with a zero origin, so the ABI is unchanged; `FramePipeline` passes the camera position into it. Pairs with the irl-editor `.irlights` PR for MC 1.21.11. Compiles on 1.21.11; verified in-game on 1.21.1.
